### PR TITLE
Add "Link to Mini Widget" setting for notifications

### DIFF
--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationFragment.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationFragment.java
@@ -1,6 +1,8 @@
 package de.jeisfeld.randomimage.notifications;
 
 import android.app.DialogFragment;
+import android.appwidget.AppWidgetManager;
+import android.content.ComponentName;
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Vibrator;
@@ -15,6 +17,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 
 import de.jeisfeld.randomimage.ConfigureImageListActivity;
@@ -25,6 +28,7 @@ import de.jeisfeld.randomimage.util.ImageRegistry;
 import de.jeisfeld.randomimage.util.ImageRegistry.ListFiltering;
 import de.jeisfeld.randomimage.util.PreferenceUtil;
 import de.jeisfeld.randomimage.view.TimeSelectorPreference;
+import de.jeisfeld.randomimage.widgets.MiniWidget;
 import de.jeisfeld.randomimage.widgets.WidgetSettingsActivity;
 import de.jeisfeld.randomimagelib.R;
 
@@ -58,6 +62,7 @@ public class NotificationConfigurationFragment extends PreferenceFragment {
 		handleNotificationCreation();
 
 		configureListNameProperty();
+		configureMiniWidgetProperty();
 		bindPreferenceSummaryToValue(R.string.key_notification_timer_duration);
 		bindPreferenceSummaryToValue(R.string.key_notification_timer_variance);
 		bindPreferenceSummaryToValue(R.string.key_notification_daily_start_time);
@@ -259,6 +264,10 @@ public class NotificationConfigurationFragment extends PreferenceFragment {
 			PreferenceUtil.setIndexedSharedPreferenceBoolean(R.string.key_notification_detail_prevent_screen_timeout, mNotificationId,
 					PreferenceUtil.getSharedPreferenceBoolean(R.string.key_pref_detail_prevent_screen_timeout));
 		}
+		if (!PreferenceUtil.hasIndexedSharedPreference(R.string.key_notification_mini_widget, mNotificationId)) {
+			isUpdated = true;
+			PreferenceUtil.setIndexedSharedPreferenceInt(R.string.key_notification_mini_widget, mNotificationId, 0);
+		}
 
 		return isUpdated;
 	}
@@ -366,6 +375,8 @@ public class NotificationConfigurationFragment extends PreferenceFragment {
 				PreferenceUtil.getIndexedSharedPreferenceBoolean(R.string.key_notification_detail_change_with_tap, mNotificationId, false));
 		PreferenceUtil.setSharedPreferenceBoolean(R.string.key_notification_detail_prevent_screen_timeout,
 				PreferenceUtil.getIndexedSharedPreferenceBoolean(R.string.key_notification_detail_prevent_screen_timeout, mNotificationId, false));
+		PreferenceUtil.setSharedPreferenceIntString(R.string.key_notification_mini_widget,
+				PreferenceUtil.getIndexedSharedPreferenceInt(R.string.key_notification_mini_widget, mNotificationId, 0));
 	}
 
 	/**
@@ -408,6 +419,56 @@ public class NotificationConfigurationFragment extends PreferenceFragment {
 	}
 
 	/**
+	 * Configure the property for the linked mini widget.
+	 */
+	private void configureMiniWidgetProperty() {
+		ListPreference preference = (ListPreference) findPreference(getString(R.string.key_notification_mini_widget));
+
+		int[] widgetIds = AppWidgetManager.getInstance(getActivity())
+				.getAppWidgetIds(new ComponentName(getActivity(), MiniWidget.class));
+		if (widgetIds != null) {
+			Arrays.sort(widgetIds);
+		}
+		else {
+			widgetIds = new int[0];
+		}
+
+		ArrayList<String> entries = new ArrayList<>();
+		ArrayList<String> entryValues = new ArrayList<>();
+		entries.add(getString(R.string.pref_value_none));
+		entryValues.add("0");
+
+		for (int i = 0; i < widgetIds.length; i++) {
+			int widgetId = widgetIds[i];
+			String widgetName = PreferenceUtil.getIndexedSharedPreferenceString(R.string.key_widget_display_name, widgetId);
+			if (widgetName == null || widgetName.isEmpty()) {
+				widgetName = getString(R.string.mini_widget_display_name) + " " + (i + 1);
+			}
+			entries.add(widgetName);
+			entryValues.add(Integer.toString(widgetId));
+		}
+
+		preference.setEntries(entries.toArray(new String[0]));
+		preference.setEntryValues(entryValues.toArray(new String[0]));
+
+		int storedWidgetId = PreferenceUtil.getIndexedSharedPreferenceInt(R.string.key_notification_mini_widget, mNotificationId, 0);
+		boolean hasWidget = storedWidgetId == 0;
+		for (int widgetId : widgetIds) {
+			if (widgetId == storedWidgetId) {
+				hasWidget = true;
+				break;
+			}
+		}
+		if (!hasWidget) {
+			PreferenceUtil.setIndexedSharedPreferenceInt(R.string.key_notification_mini_widget, mNotificationId, 0);
+			storedWidgetId = 0;
+		}
+		preference.setValue(Integer.toString(storedWidgetId));
+
+		bindPreferenceSummaryToValue(R.string.key_notification_mini_widget);
+	}
+
+	/**
 	 * Binds a preference's summary to its value. More specifically, when the preference's value is changed, its summary
 	 * (line of text below the preference title) is updated to reflect the value. The summary is also immediately
 	 * updated upon calling this method. The exact display format is dependent on the type of preference.
@@ -426,6 +487,7 @@ public class NotificationConfigurationFragment extends PreferenceFragment {
 				|| preferenceKey == R.string.key_notification_duration_variance_2
 				|| preferenceKey == R.string.key_notification_style
 				|| preferenceKey == R.string.key_notification_led_color
+				|| preferenceKey == R.string.key_notification_mini_widget
 				|| preferenceKey == R.string.key_notification_detail_scale_type
 				|| preferenceKey == R.string.key_notification_detail_background
 				|| preferenceKey == R.string.key_notification_detail_flip_behavior) {
@@ -586,6 +648,9 @@ public class NotificationConfigurationFragment extends PreferenceFragment {
 			else if (preference.getKey().equals(preference.getContext().getString(R.string.key_notification_detail_prevent_screen_timeout))) {
 				PreferenceUtil.setIndexedSharedPreferenceBoolean(R.string.key_notification_detail_prevent_screen_timeout,
 						mNotificationId, Boolean.parseBoolean(stringValue));
+			}
+			else if (preference.getKey().equals(preference.getContext().getString(R.string.key_notification_mini_widget))) {
+				PreferenceUtil.setIndexedSharedPreferenceInt(R.string.key_notification_mini_widget, mNotificationId, Integer.parseInt(stringValue));
 			}
 
 			return true;

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationSettingsActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationSettingsActivity.java
@@ -311,6 +311,7 @@ public class NotificationSettingsActivity extends BasePreferenceActivity {
 		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_vibration, notificationId);
 		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_colored_icon, notificationId);
 		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_display_name, notificationId);
+		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_mini_widget, notificationId);
 		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_detail_use_default, notificationId);
 		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_detail_scale_type, notificationId);
 		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_detail_background, notificationId);

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/widgets/MiniWidget.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/widgets/MiniWidget.java
@@ -9,6 +9,7 @@ import android.widget.RemoteViews;
 
 import de.jeisfeld.randomimage.Application;
 import de.jeisfeld.randomimage.DisplayRandomImageActivity;
+import de.jeisfeld.randomimage.notifications.NotificationSettingsActivity;
 import de.jeisfeld.randomimage.util.ImageUtil;
 import de.jeisfeld.randomimage.util.PreferenceUtil;
 import de.jeisfeld.randomimage.util.SystemUtil;
@@ -83,6 +84,12 @@ public class MiniWidget extends GenericWidget {
 			PreferenceUtil.removeIndexedSharedPreference(R.string.key_widget_timeout, appWidgetId);
 			PreferenceUtil.removeIndexedSharedPreference(R.string.key_widget_allowed_call_frequency, appWidgetId);
 			PreferenceUtil.removeIndexedSharedPreference(R.string.key_widget_icon_image, appWidgetId);
+			for (int notificationId : NotificationSettingsActivity.getNotificationIds()) {
+				int linkedWidgetId = PreferenceUtil.getIndexedSharedPreferenceInt(R.string.key_notification_mini_widget, notificationId, 0);
+				if (linkedWidgetId == appWidgetId) {
+					PreferenceUtil.setIndexedSharedPreferenceInt(R.string.key_notification_mini_widget, notificationId, 0);
+				}
+			}
 		}
 	}
 

--- a/RandomImageIdea/randomImageLib/src/main/res/values-de/strings_preferences_notification.xml
+++ b/RandomImageIdea/randomImageLib/src/main/res/values-de/strings_preferences_notification.xml
@@ -31,7 +31,9 @@
     <string name="pref_title_notification_detail_change_timeout">Automatische Wechselhäufigkeit</string>
     <string name="pref_title_notification_detail_change_with_tap">Tippen statt Schnippen</string>
     <string name="pref_title_notification_detail_prevent_screen_timeout">Bildschirmtimeout verhindern</string>
+    <string name="pref_title_notification_mini_widget">Mini-Widget verknüpfen</string>
     <string name="pref_title_cancel_notification">Benachrichtigung entfernen</string>
+    <string name="pref_value_none">Keine</string>
     <string name="notification_channel_system">Systembenachrichtigungen</string>
     <string name="notification_channel_image">Bildbenachrichtigungen</string>
     <string name="notification_channel_with_vibration">mit Vibration</string>

--- a/RandomImageIdea/randomImageLib/src/main/res/values-es/strings_preferences_notification.xml
+++ b/RandomImageIdea/randomImageLib/src/main/res/values-es/strings_preferences_notification.xml
@@ -31,7 +31,9 @@
     <string name="pref_title_notification_detail_change_timeout">Frecuencia de cambio automático</string>
     <string name="pref_title_notification_detail_change_with_tap">Tocar en lugar de lanzar</string>
     <string name="pref_title_notification_detail_prevent_screen_timeout">Prevenir el tiempo de espera de la pantalla</string>
+    <string name="pref_title_notification_mini_widget">Enlazar con mini widget</string>
     <string name="pref_title_cancel_notification">Borrar notificación</string>
+    <string name="pref_value_none">Ninguno</string>
     <string name="notification_channel_system">Notificaciones del sistema</string>
     <string name="notification_channel_image">Notificaciones de imagen</string>
     <string name="notification_channel_with_vibration">con vibración</string>

--- a/RandomImageIdea/randomImageLib/src/main/res/values/strings_preferences_notification.xml
+++ b/RandomImageIdea/randomImageLib/src/main/res/values/strings_preferences_notification.xml
@@ -23,6 +23,7 @@
     <string name="key_notification_vibration" translatable="false">notification_vibration</string>
     <string name="key_notification_colored_icon" translatable="false">notification_colored_icon</string>
     <string name="key_notification_display_name" translatable="false">notification_display_name</string>
+    <string name="key_notification_mini_widget" translatable="false">notification_mini_widget</string>
     <string name="key_notification_detail_use_default" translatable="false">notification_detail_use_default</string>
     <string name="key_notification_detail_scale_type" translatable="false">notification_detail_scale_type</string>
     <string name="key_notification_detail_background" translatable="false">notification_detail_background</string>
@@ -76,7 +77,9 @@
     <string name="pref_title_notification_detail_change_timeout">Automatic change frequency</string>
     <string name="pref_title_notification_detail_change_with_tap">Use tap instead of flipping</string>
     <string name="pref_title_notification_detail_prevent_screen_timeout">Prevent screen timeout</string>
+    <string name="pref_title_notification_mini_widget">Link to Mini Widget</string>
     <string name="pref_title_cancel_notification">Remove Notification</string>
+    <string name="pref_value_none">None</string>
     <string name="notification_channel_system">System notifications</string>
     <string name="notification_channel_image">Image notifications</string>
     <string name="notification_channel_with_vibration">with vibration</string>

--- a/RandomImageIdea/randomImageLib/src/main/res/xml/pref_notification.xml
+++ b/RandomImageIdea/randomImageLib/src/main/res/xml/pref_notification.xml
@@ -126,6 +126,11 @@
             android:title="@string/pref_title_notification_detail_prevent_screen_timeout" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_category_other">
+        <ListPreference
+            android:key="@string/key_notification_mini_widget"
+            android:negativeButtonText="@null"
+            android:positiveButtonText="@null"
+            android:title="@string/pref_title_notification_mini_widget" />
         <Preference
             android:key="@string/key_dummy_cancel_notification"
             android:title="@string/pref_title_cancel_notification"/>


### PR DESCRIPTION
### Motivation
- Provide a configurable link from a notification to an existing Mini Widget so notifications can reference a widget by id instead of name. 
- Persist the selection following existing indexed preference conventions (`key_notification_*.xxx`) and default to `None` (stored as id `0`).

### Description
- Added a new indexed preference key `key_notification_mini_widget` and localized UI strings (`pref_title_notification_mini_widget` and `pref_value_none`) in `strings_preferences_notification.xml` for default, German and Spanish locales. 
- Exposed the option in the settings UI by adding a `ListPreference` for `@string/key_notification_mini_widget` in `pref_notification.xml` before the Remove Notification entry. 
- Implemented `configureMiniWidgetProperty()` in `NotificationConfigurationFragment` to populate the preference entries with currently active `MiniWidget` instances (displayed by name, stored by id), initialize missing values to `0`, bind the preference summary, and persist the selection in the fragment change handler. 
- Ensured consistent lifecycle handling by copying the indexed value to non-indexed preferences, removing the indexed preference when a notification is canceled in `NotificationSettingsActivity.cancelNotification`, and resetting linked notification selections to `0` when a `MiniWidget` is deleted in `MiniWidget.onDeleted`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69722b3e51d483229f81ac943f7cebbc)