### PR TITLE
Gate linked Mini Widget notifications by activity foreground

### DIFF
--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java
@@ -42,6 +42,7 @@ import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 import de.jeisfeld.randomimage.notifications.NotificationAlarmReceiver;
+import de.jeisfeld.randomimage.notifications.NotificationSettingsActivity;
 import de.jeisfeld.randomimage.notifications.NotificationUtil;
 import de.jeisfeld.randomimage.notifications.NotificationUtil.NotificationType;
 import de.jeisfeld.randomimage.util.CachedRandomFileProvider;
@@ -790,6 +791,7 @@ public class DisplayRandomImageActivity extends StartActivity {
 		setNavigationBarFlags();
 		mChangeByTimeoutHandler.resume();
 		registerSPenListener();
+		updateLinkedWidgetNotificationState(true);
 	}
 
 	@Override
@@ -797,6 +799,33 @@ public class DisplayRandomImageActivity extends StartActivity {
 		super.onPause();
 		mChangeByTimeoutHandler.pause();
 		unregisterSPenListener();
+		updateLinkedWidgetNotificationState(false);
+	}
+
+	/**
+	 * Update linked Mini Widget notification activation based on foreground state.
+	 *
+	 * @param isActive true if the activity is in the foreground.
+	 */
+	private void updateLinkedWidgetNotificationState(final boolean isActive) {
+		if (mAppWidgetId == null) {
+			return;
+		}
+		List<Integer> notificationIds = NotificationSettingsActivity.getNotificationIdsByMiniWidgetId(mAppWidgetId);
+		if (notificationIds.isEmpty()) {
+			return;
+		}
+		for (int notificationId : notificationIds) {
+			PreferenceUtil.setIndexedSharedPreferenceBoolean(R.string.key_notification_widget_active, notificationId, isActive);
+			if (isActive) {
+				NotificationAlarmReceiver.setAlarm(this, notificationId, false);
+			}
+			else {
+				NotificationAlarmReceiver.cancelAlarm(this, notificationId, false);
+				NotificationAlarmReceiver.cancelAlarm(this, notificationId, true);
+				PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_current_alarm_timestamp, notificationId);
+			}
+		}
 	}
 
 	/**

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationAlarmReceiver.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationAlarmReceiver.java
@@ -82,6 +82,11 @@ public class NotificationAlarmReceiver extends AlarmReceiver {
 	 * @param useLastAlarmTime flag indicating if the last existing alarm time should be re-used.
 	 */
 	public static void setAlarm(final Context context, final int notificationId, final boolean useLastAlarmTime) {
+		if (!NotificationUtil.isMiniWidgetLinkedNotificationActive(notificationId)) {
+			cancelAlarm(context, notificationId, false);
+			PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_current_alarm_timestamp, notificationId);
+			return;
+		}
 		long frequency = PreferenceUtil.getIndexedSharedPreferenceLong(R.string.key_notification_timer_duration, notificationId, 0);
 		if (frequency == 0) {
 			cancelAlarm(context, notificationId, false);

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationFragment.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationFragment.java
@@ -268,6 +268,10 @@ public class NotificationConfigurationFragment extends PreferenceFragment {
 			isUpdated = true;
 			PreferenceUtil.setIndexedSharedPreferenceInt(R.string.key_notification_mini_widget, mNotificationId, 0);
 		}
+		if (!PreferenceUtil.hasIndexedSharedPreference(R.string.key_notification_widget_active, mNotificationId)) {
+			isUpdated = true;
+			PreferenceUtil.setIndexedSharedPreferenceBoolean(R.string.key_notification_widget_active, mNotificationId, false);
+		}
 
 		return isUpdated;
 	}
@@ -540,6 +544,11 @@ public class NotificationConfigurationFragment extends PreferenceFragment {
 	 * @param immediate      Flag indicating if the notification should be displayed immediately.
 	 */
 	private void initialiseNotification(final int notificationId, final boolean immediate) {
+		if (!NotificationUtil.isMiniWidgetLinkedNotificationActive(notificationId)) {
+			NotificationAlarmReceiver.cancelAlarm(getActivity(), notificationId, false);
+			PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_current_alarm_timestamp, notificationId);
+			return;
+		}
 		if (immediate) {
 			NotificationUtil.displayRandomImageNotification(getActivity(), notificationId);
 		}
@@ -650,7 +659,18 @@ public class NotificationConfigurationFragment extends PreferenceFragment {
 						mNotificationId, Boolean.parseBoolean(stringValue));
 			}
 			else if (preference.getKey().equals(preference.getContext().getString(R.string.key_notification_mini_widget))) {
-				PreferenceUtil.setIndexedSharedPreferenceInt(R.string.key_notification_mini_widget, mNotificationId, Integer.parseInt(stringValue));
+				int widgetId = Integer.parseInt(stringValue);
+				PreferenceUtil.setIndexedSharedPreferenceInt(R.string.key_notification_mini_widget, mNotificationId, widgetId);
+				PreferenceUtil.setIndexedSharedPreferenceBoolean(R.string.key_notification_widget_active, mNotificationId, false);
+				if (widgetId != 0) {
+					NotificationAlarmReceiver.cancelAlarm(getActivity(), mNotificationId, false);
+					NotificationAlarmReceiver.cancelAlarm(getActivity(), mNotificationId, true);
+					PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_current_alarm_timestamp, mNotificationId);
+					NotificationUtil.cancelRandomImageNotification(getActivity(), mNotificationId);
+				}
+				else {
+					initialiseNotification(mNotificationId, false);
+				}
 			}
 
 			return true;

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationSettingsActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationSettingsActivity.java
@@ -124,6 +124,24 @@ public class NotificationSettingsActivity extends BasePreferenceActivity {
 	}
 
 	/**
+	 * Get the ids of notifications linked to a specific Mini Widget.
+	 *
+	 * @param appWidgetId The widget id.
+	 * @return The notification ids linked to this widget.
+	 */
+	public static List<Integer> getNotificationIdsByMiniWidgetId(final int appWidgetId) {
+		List<Integer> notificationIds = getNotificationIds();
+		List<Integer> linkedNotificationIds = new ArrayList<>();
+		for (int notificationId : notificationIds) {
+			int linkedWidgetId = PreferenceUtil.getIndexedSharedPreferenceInt(R.string.key_notification_mini_widget, notificationId, 0);
+			if (linkedWidgetId == appWidgetId) {
+				linkedNotificationIds.add(notificationId);
+			}
+		}
+		return linkedNotificationIds;
+	}
+
+	/**
 	 * Set the ids of existing notifications.
 	 *
 	 * @param notificationIds the notification ids.
@@ -312,6 +330,7 @@ public class NotificationSettingsActivity extends BasePreferenceActivity {
 		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_colored_icon, notificationId);
 		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_display_name, notificationId);
 		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_mini_widget, notificationId);
+		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_widget_active, notificationId);
 		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_detail_use_default, notificationId);
 		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_detail_scale_type, notificationId);
 		PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_detail_background, notificationId);

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationUtil.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationUtil.java
@@ -224,6 +224,11 @@ public final class NotificationUtil {
 	 * @param notificationId the id of the configured notification.
 	 */
 	public static void displayRandomImageNotification(final Context context, final int notificationId) {
+		if (!isMiniWidgetLinkedNotificationActive(notificationId)) {
+			NotificationAlarmReceiver.cancelAlarm(context, notificationId, false);
+			PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_current_alarm_timestamp, notificationId);
+			return;
+		}
 		final String listName = PreferenceUtil.getIndexedSharedPreferenceString(R.string.key_notification_list_name, notificationId);
 		final ImageList imageList = ImageRegistry.getImageListByName(listName, false);
 		if (imageList == null) {
@@ -242,6 +247,20 @@ public final class NotificationUtil {
 					}
 				},
 				() -> NotificationAlarmReceiver.setAlarm(context, notificationId, false));
+	}
+
+	/**
+	 * Check if a Mini Widget linked notification is active (foreground).
+	 *
+	 * @param notificationId The notification id.
+	 * @return true if the notification is enabled or not linked to a widget.
+	 */
+	public static boolean isMiniWidgetLinkedNotificationActive(final int notificationId) {
+		int linkedWidgetId = PreferenceUtil.getIndexedSharedPreferenceInt(R.string.key_notification_mini_widget, notificationId, 0);
+		if (linkedWidgetId == 0) {
+			return true;
+		}
+		return PreferenceUtil.getIndexedSharedPreferenceBoolean(R.string.key_notification_widget_active, notificationId, false);
 	}
 
 	/**

--- a/RandomImageIdea/randomImageLib/src/main/res/values/strings_preferences_notification.xml
+++ b/RandomImageIdea/randomImageLib/src/main/res/values/strings_preferences_notification.xml
@@ -24,6 +24,7 @@
     <string name="key_notification_colored_icon" translatable="false">notification_colored_icon</string>
     <string name="key_notification_display_name" translatable="false">notification_display_name</string>
     <string name="key_notification_mini_widget" translatable="false">notification_mini_widget</string>
+    <string name="key_notification_widget_active" translatable="false">notification_widget_active</string>
     <string name="key_notification_detail_use_default" translatable="false">notification_detail_use_default</string>
     <string name="key_notification_detail_scale_type" translatable="false">notification_detail_scale_type</string>
     <string name="key_notification_detail_background" translatable="false">notification_detail_background</string>


### PR DESCRIPTION
### Motivation
- When a notification is linked to a Mini Widget (`key_notification_mini_widget` != 0), it must be disabled by default and only active while the widget-launched `DisplayRandomImageActivity` is in the foreground. 
- The goal is to prevent alarms and notification display for widget-linked notifications unless the widget-triggering activity is active, and to restore/stop alarms on activity resume/pause. 

### Description
- Add a new preference key `key_notification_widget_active` and ensure it is initialized to `false` for newly created/updated notifications via `NotificationConfigurationFragment` and cleared on cancellation in `NotificationSettingsActivity`. 
- Add `NotificationSettingsActivity.getNotificationIdsByMiniWidgetId(int)` to look up notifications linked to a specific Mini Widget, and remove the `widget_active` entry when a notification is canceled. 
- Gate alarm scheduling and display by introducing `NotificationUtil.isMiniWidgetLinkedNotificationActive(int)` and short-circuiting in `NotificationAlarmReceiver.setAlarm(...)` and `NotificationUtil.displayRandomImageNotification(...)` to avoid creating alarms or showing notifications when a linked notification is inactive. 
- When `DisplayRandomImageActivity` is started from a widget, update the `key_notification_widget_active` flag for all notifications linked to that widget on `onResume()`/`onPause()` and set/cancel alarms accordingly in `updateLinkedWidgetNotificationState(...)`. 
- Update `NotificationConfigurationFragment` to set `key_notification_widget_active` to `false` when a notification is linked to a widget and cancel any existing alarms/notifications; re-initialize alarms when unlinked. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697234cee0008322a7e3473ee69664f6)