### PR TITLE
Ensure notification duration/cancellation runs when activity is opened from a widget

### DIFF
--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java
@@ -437,15 +437,15 @@ public class DisplayRandomImageActivity extends StartActivity {
 		mAppWidgetId = getIntent().getIntExtra(STRING_EXTRA_APP_WIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID);
 		if (mAppWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
 			mAppWidgetId = null;
-			mNotificationId = getIntent().getIntExtra(STRING_EXTRA_NOTIFICATION_ID, -1);
-			if (mNotificationId == -1) {
-				mNotificationId = null;
-			}
-			else {
-				configureNotificationProperties();
-			}
+		}
+		mNotificationId = getIntent().getIntExtra(STRING_EXTRA_NOTIFICATION_ID, -1);
+		if (mNotificationId == -1) {
+			mNotificationId = null;
 		}
 		else {
+			configureNotificationProperties();
+		}
+		if (mAppWidgetId != null) {
 			configureWidgetProperties();
 		}
 		mHideNavigationBar = !mChangeImageWithSingleTap;


### PR DESCRIPTION
### Motivation
- Notification "Duration" must schedule a cancellation alarm even when the activity is launched with a linked widget, because previously the notification-specific setup was skipped whenever a widget id was present.

### Description
- Update `DisplayRandomImageActivity` intent handling to always parse/configure the `notificationId` (calling `configureNotificationProperties()`) and then, if an `appWidgetId` is present, call `configureWidgetProperties()` so notification cancellation behavior and widget configuration run together.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69723fd94398832282f83d80aea8a18b)