### PR TITLE
Add confirmation dialog for notification removal

### DIFF
--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationFragment.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationFragment.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import de.jeisfeld.randomimage.ConfigureImageListActivity;
 import de.jeisfeld.randomimage.util.DateUtil;
 import de.jeisfeld.randomimage.util.DialogUtil;
+import de.jeisfeld.randomimage.util.DialogUtil.ConfirmDialogFragment.ConfirmDialogListener;
 import de.jeisfeld.randomimage.util.DialogUtil.SelectFromListDialogFragment.SelectFromListDialogListener;
 import de.jeisfeld.randomimage.util.ImageRegistry;
 import de.jeisfeld.randomimage.util.ImageRegistry.ListFiltering;
@@ -138,9 +139,30 @@ public class NotificationConfigurationFragment extends PreferenceFragment {
 		Preference cancelNotificationPreference = findPreference(getString(R.string.key_dummy_cancel_notification));
 
 		cancelNotificationPreference.setOnPreferenceClickListener(preference -> {
-			NotificationSettingsActivity.cancelNotification(mNotificationId);
-			updateHeader();
-			getActivity().finish();
+			String notificationName = PreferenceUtil.getIndexedSharedPreferenceString(R.string.key_notification_display_name, mNotificationId);
+			if (notificationName == null || notificationName.isEmpty()) {
+				int index = NotificationSettingsActivity.getNotificationIds().indexOf(mNotificationId);
+				if (index >= 0) {
+					notificationName = getString(R.string.pref_heading_notifcation) + " " + (index + 1);
+				}
+				else {
+					notificationName = getString(R.string.pref_heading_notifcation);
+				}
+			}
+			String finalNotificationName = notificationName;
+			DialogUtil.displayConfirmationMessage(getActivity(), new ConfirmDialogListener() {
+				@Override
+				public void onDialogPositiveClick(final DialogFragment dialog) {
+					NotificationSettingsActivity.cancelNotification(mNotificationId);
+					updateHeader();
+					getActivity().finish();
+				}
+
+				@Override
+				public void onDialogNegativeClick(final DialogFragment dialog) {
+					// do nothing
+				}
+			}, null, R.string.button_remove, R.string.dialog_confirmation_remove_notification, finalNotificationName);
 			return true;
 		});
 

--- a/RandomImageIdea/randomImageLib/src/main/res/values-de/strings_dialogs.xml
+++ b/RandomImageIdea/randomImageLib/src/main/res/values-de/strings_dialogs.xml
@@ -105,6 +105,7 @@
     <string name="dialog_confirmation_add_folder">Wollen Sie das Verzeichnis „%1$s” zur Bildliste hinzufügen?</string>
     <string name="dialog_confirmation_add_folder_recursively">Wollen Sie das Verzeichnis „%1$s” samt aller Unterverzeichnisse zur Bildliste hinzufügen?</string>
     <string name="dialog_confirmation_add_nested_list">Wollen Sie die Bildliste „%1$s” zur Liste „%2$s” als Unterliste hinzufügen?</string>
+    <string name="dialog_confirmation_remove_notification">Wollen Sie die Benachrichtigung „%1$s” wirklich entfernen?</string>
     <string name="dialog_confirmation_overwrite_list_single">Die Liste „%2$s” existiert bereits. Wollen Sie sie mit dem Backup überschreiben?</string>
     <string name="dialog_confirmation_overwrite_list_multiple">%1$d der ausgewählen Listen existieren bereits. Wollen Sie diese mit dem Backup überschreiben?</string>
     <string name="dialog_confirmation_overwrite_backup_single">Das Backup von „%2$s” existiert bereits. Wollen Sie es überschreiben?</string>

--- a/RandomImageIdea/randomImageLib/src/main/res/values-es/strings_dialogs.xml
+++ b/RandomImageIdea/randomImageLib/src/main/res/values-es/strings_dialogs.xml
@@ -104,6 +104,7 @@
     <string name="dialog_confirmation_add_folder">¿Desea agregar la carpeta «%1$s» a la lista de imágenes?</string>
     <string name="dialog_confirmation_add_folder_recursively">¿Desea agregar la carpeta «%1$s» y todas sus subcarpetas a la lista de imágenes?</string>
     <string name="dialog_confirmation_add_nested_list">¿Desea agregar la lista de imágenes «%1$s» a la lista «%2$s» como sublista?</string>
+    <string name="dialog_confirmation_remove_notification">¿Realmente desea eliminar la notificación «%1$s»?</string>
     <string name="dialog_confirmation_overwrite_list_single">La lista «%2$s» ya existe. ¿Quiere sobrescribirlo con la copia de seguridad?</string>
     <string name="dialog_confirmation_overwrite_list_multiple">%1$d de las listas seleccionadas ya existen. ¿Quiere sobrescribir esto con la copia de seguridad?</string>
     <string name="dialog_confirmation_overwrite_backup_single">La copia de seguridad de «%2$s» ya existe. ¿Quiere sobrescribirlo?</string>

--- a/RandomImageIdea/randomImageLib/src/main/res/values/strings_dialogs.xml
+++ b/RandomImageIdea/randomImageLib/src/main/res/values/strings_dialogs.xml
@@ -106,6 +106,7 @@
     <string name="dialog_confirmation_add_folder">Do you want to add the folder “%1$s” to the image list?</string>
     <string name="dialog_confirmation_add_folder_recursively">Do you want to add the folder “%1$s” and all its subfolders to the image list?</string>
     <string name="dialog_confirmation_add_nested_list">Do you want to add the image list “%1$s” to the list “%2$s” as nested list?</string>
+    <string name="dialog_confirmation_remove_notification">Do you really want to remove the notification “%1$s”?</string>
     <string name="dialog_confirmation_overwrite_list_single">The list “%2$s” exists already. Do you want to overwrite it with the backup?</string>
     <string name="dialog_confirmation_overwrite_list_multiple">%1$d of the selected lists exist already. Do you want to overwrite them with the backup?</string>
     <string name="dialog_confirmation_overwrite_backup_single">The list “%2$s” has already a backup. Do you want to overwrite it?</string>


### PR DESCRIPTION
### Motivation
- Prevent accidental immediate deletion when tapping the `Remove Notification` button by asking the user to confirm. 
- Use the app's standard dialog helper and localized resources (`DialogUtil`) to keep behavior consistent across languages.

### Description
- Show a confirmation dialog in `addCancelNotificationListener` in `NotificationConfigurationFragment` via `DialogUtil.displayConfirmationMessage` and a `ConfirmDialogListener` before removing a notification. 
- Compute a readable notification label (display name or fallback header like "Notification X") to include in the confirmation prompt. 
- On positive confirmation call `NotificationSettingsActivity.cancelNotification`, `updateHeader()` and `getActivity().finish()`; negative confirmation is a no-op. 
- Add the localized prompt string `dialog_confirmation_remove_notification` to `values/strings_dialogs.xml`, `values-de/strings_dialogs.xml` and `values-es/strings_dialogs.xml` and add the required `ConfirmDialogListener` import.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a0bf654588322a432ffa27fdfdf57)