### PR TITLE
Fix GIF scale handling in PinchImageView

### DIFF
--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/view/PinchImageView.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/view/PinchImageView.java
@@ -323,8 +323,8 @@ public class PinchImageView extends ImageView {
 	 * @return The natural scale factor fitting the image into the view.
 	 */
 	private float getNaturalScaleFactor() {
-		float heightFactor = 1f * getHeight() / mDrawable.getIntrinsicHeight();
-		float widthFactor = 1f * getWidth() / mDrawable.getIntrinsicWidth();
+		float heightFactor = 1f * getHeight() / getDisplayedDrawableHeight();
+		float widthFactor = 1f * getWidth() / getDisplayedDrawableWidth();
 
 		switch (mScaleType) {
 		case STRETCH:
@@ -508,13 +508,45 @@ public class PinchImageView extends ImageView {
 				setImageMatrix(null);
 			}
 			else {
+				float displayedWidth = getDisplayedDrawableWidth();
+				float displayedHeight = getDisplayedDrawableHeight();
+
 				Matrix matrix = new Matrix();
-				matrix.setTranslate(-mPosX * mDrawable.getIntrinsicWidth(), -mPosY * mDrawable.getIntrinsicHeight());
+				matrix.postTranslate(-mDrawable.getIntrinsicWidth() / 2.0f, -mDrawable.getIntrinsicHeight() / 2.0f);
+				if (mRotationAngle != 0) {
+					matrix.postRotate(mRotationAngle);
+				}
 				matrix.postScale(mScaleFactor, mScaleFactor);
-				matrix.postTranslate(getWidth() / 2.0f, getHeight() / 2.0f);
+				matrix.postTranslate(
+						getWidth() / 2.0f + (ONE_HALF - mPosX) * displayedWidth * mScaleFactor,
+						getHeight() / 2.0f + (ONE_HALF - mPosY) * displayedHeight * mScaleFactor);
 				setImageMatrix(matrix);
 			}
 		}
+	}
+
+	/**
+	 * Get the width of the drawable after applying the configured rotation.
+	 *
+	 * @return The displayed drawable width.
+	 */
+	private int getDisplayedDrawableWidth() {
+		if (Math.abs(mRotationAngle) % 180 == 90) {
+			return mDrawable.getIntrinsicHeight();
+		}
+		return mDrawable.getIntrinsicWidth();
+	}
+
+	/**
+	 * Get the height of the drawable after applying the configured rotation.
+	 *
+	 * @return The displayed drawable height.
+	 */
+	private int getDisplayedDrawableHeight() {
+		if (Math.abs(mRotationAngle) % 180 == 90) {
+			return mDrawable.getIntrinsicWidth();
+		}
+		return mDrawable.getIntrinsicHeight();
 	}
 
 	/**


### PR DESCRIPTION
### Motivation
- Animated GIFs in `DisplayRandomImageActivity`/`PinchImageView` were ignoring the configured `ScaleType` and rotation logic and always appeared as with `FIT`, causing inconsistent initial scale, rotation and pan behavior compared to static images.

### Description
- Use the drawable dimensions after any configured 90°/270° rotation in `getNaturalScaleFactor()` by replacing intrinsic size references with `getDisplayedDrawableWidth()`/`getDisplayedDrawableHeight()` so scale calculations match the displayed orientation.
- Apply a center-based matrix transform in `setMatrix()` that rotates the drawable around its center (if `mRotationAngle` != 0), then scales and translates using the effective displayed drawable size and the current `mPosX`/`mPosY`, so GIFs respect `FIT`, `STRETCH`, `TURN_FIT` and `TURN_STRETCH` consistently with bitmaps.
- Add helper methods `getDisplayedDrawableWidth()` and `getDisplayedDrawableHeight()` to compute drawable dimensions after rotation and reuse those values in layout/position math.
- Preserve existing behavior for full-resolution snapshots and the special-case handling that avoids applying full-resolution replacement for animated GIFs.

### Testing
- Attempted to compile `:randomImageLib` with the project Gradle wrapper using `bash ./gradlew :randomImageLib:compileDebugJavaWithJavac`, which failed due to missing Gradle wrapper classes in the checkout (environment limitation).
- Attempted to compile with the system Gradle using `gradle :randomImageLib:compileDebugJavaWithJavac`, which failed because the installed Gradle is `8.14.3` while the project requires at least `9.1.0` (version mismatch).
- No automated unit/UI tests were run in this environment due to the build/tooling issues above; the change is limited to `RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/view/PinchImageView.java` and is ready for verification in an environment with the proper Gradle wrapper or updated Gradle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc7eded02483228adfab2ffa9ae6bb)