### PR TITLE
Restore launcher relaunch behavior for DisplayRandomImageActivity

### DIFF
--- a/RandomImageIdea/randomImageLib/src/main/AndroidManifest.xml
+++ b/RandomImageIdea/randomImageLib/src/main/AndroidManifest.xml
@@ -42,6 +42,7 @@
             android:name="de.jeisfeld.randomimage.DisplayRandomImageActivity"
             android:exported="true"
             android:label="@string/app_name_short"
+            android:launchMode="singleTop"
             android:theme="@style/AppTheme.Fullscreen">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java
@@ -370,6 +370,30 @@ public class DisplayRandomImageActivity extends StartActivity {
 		context.startActivity(intent);
 	}
 
+	/**
+	 * Check if an intent came from the launcher.
+	 *
+	 * @param intent The intent to check.
+	 * @return {@code true} if the launcher started the activity.
+	 */
+	private boolean isLauncherIntent(final Intent intent) {
+		return intent != null
+				&& Intent.ACTION_MAIN.equals(intent.getAction())
+				&& (intent.hasCategory(Intent.CATEGORY_LAUNCHER)
+				|| intent.hasCategory("android.intent.category.MULTIWINDOW_LAUNCHER"));
+	}
+
+	@Override
+	protected final void onNewIntent(final Intent intent) {
+		super.onNewIntent(intent);
+		if (isLauncherIntent(intent)) {
+			finish();
+			startActivity(createIntent(this, null, null, true, null, null));
+			return;
+		}
+		setIntent(intent);
+	}
+
 	@Override
 	protected final void onCreate(final Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);


### PR DESCRIPTION
### Motivation
- The launcher should always present the image-list selection flow before opening `DisplayRandomImageActivity`, but tapping the launcher a second time currently resumes a retained `DisplayRandomImageActivity` instance instead of restarting the expected flow. 
- The change aims to detect launcher re-entry and trigger a fresh launcher flow so the user sees the image lists on each launcher tap.

### Description
- Set `DisplayRandomImageActivity` to `singleTop` in the manifest by adding `android:launchMode="singleTop"` so launcher taps are delivered via `onNewIntent` to the top activity instance.  
- Add `isLauncherIntent(Intent)` to detect `Intent.ACTION_MAIN` intents with `Intent.CATEGORY_LAUNCHER` or `android.intent.category.MULTIWINDOW_LAUNCHER`.  
- Override `onNewIntent(Intent)` to finish the retained display and start a fresh launcher flow via `startActivity(createIntent(this, null, null, true, null, null))` when a launcher intent is detected, and call `setIntent(intent)` for non-launcher intents.

### Testing
- Attempted `./gradlew :randomImageLib:assembleDebug`, which failed with `Permission denied` because the Gradle wrapper was not executable in this environment.  
- Attempted `bash ./gradlew :randomImageLib:assembleDebug`, which failed with `ClassNotFoundException: org.gradle.wrapper.GradleWrapperMain` because the Gradle wrapper classes are missing from the repository, so an automated build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc89ba189c8322b59ce991bbd39e84)