### PR TITLE
Fix Mini Widget linked notification activation

### DIFF
--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java
@@ -354,6 +354,16 @@ public class DisplayRandomImageActivity extends StartActivity {
 	}
 
 	/**
+	 * Check if there is an existing activity started from a certain widget.
+	 *
+	 * @param appWidgetId The appWidgetId that has triggered the activity.
+	 * @return true if a widget-linked DisplayRandomImageActivity currently exists.
+	 */
+	public static boolean hasStartedActivityForWidget(final int appWidgetId) {
+		return WIDGET_MAP.get(appWidgetId) != null;
+	}
+
+	/**
 	 * Static helper method to start the activity for the contents of an image folder.
 	 *
 	 * @param context    The context starting this activity.
@@ -720,6 +730,7 @@ public class DisplayRandomImageActivity extends StartActivity {
 			return;
 		}
 		WIDGET_MAP.put(mAppWidgetId, this);
+		updateLinkedWidgetNotificationState(true);
 
 		PreferenceUtil.setIndexedSharedPreferenceLong(R.string.key_widget_last_usage_time, mAppWidgetId, currentTime);
 
@@ -769,6 +780,7 @@ public class DisplayRandomImageActivity extends StartActivity {
 			}
 		}
 		if (mAppWidgetId != null) {
+			updateLinkedWidgetNotificationState(false);
 			WIDGET_MAP.delete(mAppWidgetId);
 			if (PreferenceUtil.getIndexedSharedPreferenceLong(R.string.key_widget_timeout, mAppWidgetId, 0) > 0) {
 				WidgetAlarmReceiver.cancelAlarm(this, mAppWidgetId, true);
@@ -806,7 +818,6 @@ public class DisplayRandomImageActivity extends StartActivity {
 		setNavigationBarFlags();
 		mChangeByTimeoutHandler.resume();
 		registerSPenListener();
-		updateLinkedWidgetNotificationState(true);
 	}
 
 	@Override
@@ -814,13 +825,12 @@ public class DisplayRandomImageActivity extends StartActivity {
 		super.onPause();
 		mChangeByTimeoutHandler.pause();
 		unregisterSPenListener();
-		updateLinkedWidgetNotificationState(false);
 	}
 
 	/**
-	 * Update linked Mini Widget notification activation based on foreground state.
+	 * Update linked Mini Widget notification activation based on whether the widget activity is started.
 	 *
-	 * @param isActive true if the activity is in the foreground.
+	 * @param isActive true if the activity is started and not yet destroyed.
 	 */
 	private void updateLinkedWidgetNotificationState(final boolean isActive) {
 		if (mAppWidgetId == null) {

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationFragment.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationFragment.java
@@ -29,6 +29,7 @@ import de.jeisfeld.randomimage.util.ImageRegistry;
 import de.jeisfeld.randomimage.util.ImageRegistry.ListFiltering;
 import de.jeisfeld.randomimage.util.PreferenceUtil;
 import de.jeisfeld.randomimage.view.TimeSelectorPreference;
+import de.jeisfeld.randomimage.DisplayRandomImageActivity;
 import de.jeisfeld.randomimage.widgets.MiniWidget;
 import de.jeisfeld.randomimage.widgets.WidgetSettingsActivity;
 import de.jeisfeld.randomimagelib.R;
@@ -683,7 +684,8 @@ public class NotificationConfigurationFragment extends PreferenceFragment {
 			else if (preference.getKey().equals(preference.getContext().getString(R.string.key_notification_mini_widget))) {
 				int widgetId = Integer.parseInt(stringValue);
 				PreferenceUtil.setIndexedSharedPreferenceInt(R.string.key_notification_mini_widget, mNotificationId, widgetId);
-				PreferenceUtil.setIndexedSharedPreferenceBoolean(R.string.key_notification_widget_active, mNotificationId, false);
+				PreferenceUtil.setIndexedSharedPreferenceBoolean(R.string.key_notification_widget_active, mNotificationId,
+						widgetId != 0 && DisplayRandomImageActivity.hasStartedActivityForWidget(widgetId));
 				if (widgetId != 0) {
 					NotificationAlarmReceiver.cancelAlarm(getActivity(), mNotificationId, false);
 					NotificationAlarmReceiver.cancelAlarm(getActivity(), mNotificationId, true);


### PR DESCRIPTION
### Motivation
- Linked Random Image notifications should be active when a `DisplayRandomImageActivity` has been started for the configured Mini Widget, but they were not being kept active across activity lifecycle transitions.
- The goal is to ensure notifications linked to a Mini Widget become active immediately when an activity exists and remain enabled for the full lifetime of that widget-launched activity.

### Description
- Added `DisplayRandomImageActivity.hasStartedActivityForWidget(int)` to detect whether a widget-launched `DisplayRandomImageActivity` already exists. 
- Enabled linked-notification activation at widget-activity start by calling `updateLinkedWidgetNotificationState(true)` when the activity is registered in `WIDGET_MAP`.
- Disabled linked-notification activation at widget-activity teardown by calling `updateLinkedWidgetNotificationState(false)` in `onDestroy` before removing the activity from `WIDGET_MAP`.
- Updated notification linking flow in `NotificationConfigurationFragment` to initialize `key_notification_widget_active` based on `DisplayRandomImageActivity.hasStartedActivityForWidget(...)` so newly-linked notifications become active immediately if the widget activity is already started.

### Testing
- Ran `git diff --check` to validate no whitespace or index issues; it completed successfully.
- Attempted to run unit tests with the Gradle wrapper via `bash ./gradlew testDebugUnitTest`, but the Gradle wrapper JAR is missing in this checkout so the wrapper could not start. 
- Attempted to run tests with the installed `gradle` via `gradle testDebugUnitTest`, but dependency resolution failed (HTTP 403 from Maven Central / Google repositories) in this environment, so the build could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc8e4f5a44832289b4d7160cd88afe)