### PR TITLE
Restore linked widget notification reactivation

### DIFF
--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java
@@ -833,11 +833,10 @@ public class DisplayRandomImageActivity extends StartActivity {
 		for (int notificationId : notificationIds) {
 			PreferenceUtil.setIndexedSharedPreferenceBoolean(R.string.key_notification_widget_active, notificationId, isActive);
 			if (isActive) {
-				NotificationAlarmReceiver.setAlarm(this, notificationId, false);
+				NotificationAlarmReceiver.setAlarm(this, notificationId, true);
 			}
 			else {
 				NotificationAlarmReceiver.cancelAlarm(this, notificationId, false);
-				PreferenceUtil.removeIndexedSharedPreference(R.string.key_notification_current_alarm_timestamp, notificationId);
 			}
 		}
 	}


### PR DESCRIPTION
### Motivation
- Ensure `updateLinkedWidgetNotificationState` reactivates Random Image notifications when a widget-launched `DisplayRandomImageActivity` resumes by restoring previously scheduled alarm timestamps instead of discarding them, fixing a recent regression.

### Description
- Update `DisplayRandomImageActivity.updateLinkedWidgetNotificationState` to call `NotificationAlarmReceiver.setAlarm(this, notificationId, true)` when `isActive` is true and stop removing `key_notification_current_alarm_timestamp` on pause so the previously stored alarm time is preserved; change is in `RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java`.

### Testing
- Verified the environment with `gradle -v` (succeeded) and attempted to run `:randomImageLib:compileDebugJavaWithJavac` with the Gradle wrapper and with the system `gradle`, but the builds could not complete in this environment because the Gradle wrapper jar is missing and remote artifact resolution to Maven/Google returned HTTP 403, so a full build could not be validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc913c58548322aabf11157157c48d)