### PR TITLE
Restore linked widget notification activation

### DIFF
--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java
@@ -387,6 +387,7 @@ public class DisplayRandomImageActivity extends StartActivity {
 	protected final void onNewIntent(final Intent intent) {
 		super.onNewIntent(intent);
 		if (isLauncherIntent(intent)) {
+			updateLinkedWidgetNotificationState(true);
 			finish();
 			startActivity(createIntent(this, null, null, true, null, null));
 			return;


### PR DESCRIPTION
### Motivation
- Ensure Random Image notifications linked to a mini-widget are re-activated when a widget-launched `DisplayRandomImageActivity` is replaced by a launcher relaunch, restoring behavior lost after recent launcher-relaunch changes.

### Description
- Call `updateLinkedWidgetNotificationState(true)` in `onNewIntent()` of `RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/DisplayRandomImageActivity.java` when the incoming intent is a launcher intent so linked widget notifications are re-enabled before finishing the widget-launched activity.

### Testing
- Attempted to compile with `bash ./gradlew :randomImageLib:compileDebugJavaWithJavac`, which failed in this environment because the Gradle wrapper JAR is missing (`org.gradle.wrapper.GradleWrapperMain`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc913c58548322aabf11157157c48d)