### PR TITLE
Relax notification permission startup handling

### DIFF
--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/SettingsFragment.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/SettingsFragment.java
@@ -149,11 +149,16 @@ public class SettingsFragment extends PreferenceFragment {
 
 	@Override
 	public final void onRequestPermissionsResult(final int requestCode, final String[] permissions, final int[] grantResults) {
-		if (requestCode == REQUEST_CODE_NOTIFICATION_PERMISSION && NotificationPermissionUtil.hasNotificationPermission(getActivity())) {
-			CheckBoxPreference showListNotificationPreference =
-					(CheckBoxPreference) findPreference(getString(R.string.key_pref_show_list_notification));
-			showListNotificationPreference.setChecked(true);
-			PreferenceUtil.setSharedPreferenceBoolean(R.string.key_pref_show_list_notification, true);
+		if (requestCode == REQUEST_CODE_NOTIFICATION_PERMISSION) {
+			if (NotificationPermissionUtil.hasNotificationPermission(getActivity())) {
+				CheckBoxPreference showListNotificationPreference =
+						(CheckBoxPreference) findPreference(getString(R.string.key_pref_show_list_notification));
+				showListNotificationPreference.setChecked(true);
+				PreferenceUtil.setSharedPreferenceBoolean(R.string.key_pref_show_list_notification, true);
+			}
+			else {
+				DialogUtil.displayInfo(getActivity(), R.string.dialog_confirmation_need_notification_permission);
+			}
 		}
 	}
 
@@ -481,7 +486,17 @@ public class SettingsFragment extends PreferenceFragment {
 			// enforce notification permission when enabling list change notifications
 			else if (preference.getKey().equals(preference.getContext().getString(R.string.key_pref_show_list_notification))) {
 				if ((Boolean) value && !NotificationPermissionUtil.hasNotificationPermission(preference.getContext())) {
-					NotificationPermissionUtil.requestNotificationPermission(SettingsFragment.this, REQUEST_CODE_NOTIFICATION_PERMISSION);
+					DialogUtil.displayConfirmationMessage(getActivity(), new ConfirmDialogListener() {
+						@Override
+						public void onDialogPositiveClick(final DialogFragment dialog) {
+							NotificationPermissionUtil.requestNotificationPermission(SettingsFragment.this, REQUEST_CODE_NOTIFICATION_PERMISSION);
+						}
+
+						@Override
+						public void onDialogNegativeClick(final DialogFragment dialog) {
+							// do nothing
+						}
+					}, R.string.title_dialog_request_permission, R.string.button_continue, R.string.dialog_confirmation_need_notification_permission);
 					return false;
 				}
 				PreferenceUtil.setSharedPreferenceBoolean(R.string.key_pref_show_list_notification, (Boolean) value);

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/SettingsFragment.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/SettingsFragment.java
@@ -157,7 +157,7 @@ public class SettingsFragment extends PreferenceFragment {
 				PreferenceUtil.setSharedPreferenceBoolean(R.string.key_pref_show_list_notification, true);
 			}
 			else {
-				DialogUtil.displayInfo(getActivity(), R.string.dialog_confirmation_need_notification_permission);
+				// keep the preference disabled
 			}
 		}
 	}

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/SettingsFragment.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/SettingsFragment.java
@@ -32,6 +32,7 @@ import de.jeisfeld.randomimage.util.DialogUtil.ConfirmDialogFragment.ConfirmDial
 import de.jeisfeld.randomimage.util.FileUtil;
 import de.jeisfeld.randomimage.util.ImageRegistry;
 import de.jeisfeld.randomimage.util.MediaStoreUtil;
+import de.jeisfeld.randomimage.util.NotificationPermissionUtil;
 import de.jeisfeld.randomimage.util.PreferenceUtil;
 import de.jeisfeld.randomimage.util.SystemUtil;
 import de.jeisfeld.randomimage.util.SystemUtil.ApplicationInfo;
@@ -46,6 +47,11 @@ import de.jeisfeld.randomimagelib.R;
  * Fragment for displaying the settings.
  */
 public class SettingsFragment extends PreferenceFragment {
+	/**
+	 * The request code used to query for notification permission.
+	 */
+	private static final int REQUEST_CODE_NOTIFICATION_PERMISSION = 4;
+
 	/**
 	 * Field holding the value of the language preference, in order to detect a real change.
 	 */
@@ -139,6 +145,16 @@ public class SettingsFragment extends PreferenceFragment {
 	@Override
 	public final void onResume() {
 		super.onResume();
+	}
+
+	@Override
+	public final void onRequestPermissionsResult(final int requestCode, final String[] permissions, final int[] grantResults) {
+		if (requestCode == REQUEST_CODE_NOTIFICATION_PERMISSION && NotificationPermissionUtil.hasNotificationPermission(getActivity())) {
+			CheckBoxPreference showListNotificationPreference =
+					(CheckBoxPreference) findPreference(getString(R.string.key_pref_show_list_notification));
+			showListNotificationPreference.setChecked(true);
+			PreferenceUtil.setSharedPreferenceBoolean(R.string.key_pref_show_list_notification, true);
+		}
 	}
 
 	/**
@@ -461,6 +477,14 @@ public class SettingsFragment extends PreferenceFragment {
 						System.exit(0);
 					}
 				}
+			}
+			// enforce notification permission when enabling list change notifications
+			else if (preference.getKey().equals(preference.getContext().getString(R.string.key_pref_show_list_notification))) {
+				if ((Boolean) value && !NotificationPermissionUtil.hasNotificationPermission(preference.getContext())) {
+					NotificationPermissionUtil.requestNotificationPermission(SettingsFragment.this, REQUEST_CODE_NOTIFICATION_PERMISSION);
+					return false;
+				}
+				PreferenceUtil.setSharedPreferenceBoolean(R.string.key_pref_show_list_notification, (Boolean) value);
 			}
 			// show/hide regex preferences in dependence of main setting
 			else if (preference.getKey().equals(preference.getContext().getString(R.string.key_pref_use_regex_filter))) {

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/StartActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/StartActivity.java
@@ -61,7 +61,7 @@ public abstract class StartActivity extends BaseActivity {
 					? R.string.dialog_confirmation_need_image_permission : R.string.dialog_confirmation_need_read_permission);
 		}
 		else if (shouldRequestNotificationPermissionOnStartup() && NotificationPermissionUtil.shouldRequestStartupNotificationPermission(this)) {
-			NotificationPermissionUtil.requestNotificationPermission(this, REQUEST_CODE_STARTUP_NOTIFICATION_PERMISSION);
+			NotificationPermissionUtil.requestStartupNotificationPermission(this, REQUEST_CODE_STARTUP_NOTIFICATION_PERMISSION);
 		}
 	}
 

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/StartActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/StartActivity.java
@@ -9,12 +9,16 @@ import android.os.Build;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import de.jeisfeld.randomimage.util.DialogUtil;
 import de.jeisfeld.randomimage.util.DialogUtil.ConfirmDialogFragment.ConfirmDialogListener;
 import de.jeisfeld.randomimage.util.ImageUtil;
+import de.jeisfeld.randomimage.util.NotificationPermissionUtil;
 import de.jeisfeld.randomimage.util.SystemUtil;
 import de.jeisfeld.randomimagelib.R;
 
@@ -28,40 +32,25 @@ public abstract class StartActivity extends BaseActivity {
 	 */
 	protected static final int REQUEST_CODE_PERMISSION = 3;
 
+	/**
+	 * The request code used to query for notification permission without blocking the app startup.
+	 */
+	private static final int REQUEST_CODE_STARTUP_NOTIFICATION_PERMISSION = 4;
+
 	// OVERRIDABLE
 	@Override
 	protected void onCreate(final Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
-		int readPermission = ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE);
-		int writePermission = ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-		int locationPermission = PackageManager.PERMISSION_GRANTED;
-		int mediaPermission = PackageManager.PERMISSION_GRANTED;
-		int notificationPermission = PackageManager.PERMISSION_GRANTED;
-		if (Build.VERSION.SDK_INT >= VERSION_CODES.R) {
-			locationPermission = ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_MEDIA_LOCATION);
-		}
-		if (Build.VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
-			mediaPermission = ContextCompat.checkSelfPermission(this, permission.READ_MEDIA_IMAGES);
-			notificationPermission = ContextCompat.checkSelfPermission(this, permission.POST_NOTIFICATIONS);
-		}
+		final boolean imagePermissionMissing = isImagePermissionMissing();
+		final boolean notificationPermissionMissing = !NotificationPermissionUtil.hasNotificationPermission(this);
+		final boolean mustHaveNotificationPermission = isNotificationPermissionRequiredForActivity() && notificationPermissionMissing;
 
-		if ((!SystemUtil.isAtLeastVersion(VERSION_CODES.TIRAMISU) && readPermission != PackageManager.PERMISSION_GRANTED) // BOOLEAN_EXPRESSION_COMPLEXITY
-				|| (!SystemUtil.isAtLeastVersion(VERSION_CODES.Q) && writePermission != PackageManager.PERMISSION_GRANTED)
-				|| (SystemUtil.isAtLeastVersion(VERSION_CODES.R) && locationPermission != PackageManager.PERMISSION_GRANTED)
-				|| (SystemUtil.isAtLeastVersion(VERSION_CODES.TIRAMISU)
-				&& (mediaPermission != PackageManager.PERMISSION_GRANTED || notificationPermission != PackageManager.PERMISSION_GRANTED))) {
+		if (imagePermissionMissing || mustHaveNotificationPermission) {
 			DialogUtil.displayConfirmationMessage(this, new ConfirmDialogListener() {
 				@Override
 				public void onDialogPositiveClick(final DialogFragment dialog) {
-					ActivityCompat.requestPermissions(StartActivity.this,
-							Build.VERSION.SDK_INT >= VERSION_CODES.TIRAMISU
-									? new String[]{permission.ACCESS_MEDIA_LOCATION, permission.READ_MEDIA_IMAGES, permission.POST_NOTIFICATIONS}
-									: Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
-									? new String[]{permission.READ_EXTERNAL_STORAGE, permission.WRITE_EXTERNAL_STORAGE,
-									permission.ACCESS_MEDIA_LOCATION}
-									: new String[]{permission.READ_EXTERNAL_STORAGE, permission.WRITE_EXTERNAL_STORAGE},
-							REQUEST_CODE_PERMISSION);
+					ActivityCompat.requestPermissions(StartActivity.this, createPermissionRequest(mustHaveNotificationPermission), REQUEST_CODE_PERMISSION);
 				}
 
 				@Override
@@ -71,15 +60,88 @@ public abstract class StartActivity extends BaseActivity {
 			}, R.string.title_dialog_request_permission, R.string.button_continue, SystemUtil.isAtLeastVersion(VERSION_CODES.TIRAMISU)
 					? R.string.dialog_confirmation_need_image_permission : R.string.dialog_confirmation_need_read_permission);
 		}
+		else if (shouldRequestNotificationPermissionOnStartup() && NotificationPermissionUtil.shouldRequestStartupNotificationPermission(this)) {
+			NotificationPermissionUtil.requestNotificationPermission(this, REQUEST_CODE_STARTUP_NOTIFICATION_PERMISSION);
+		}
+	}
+
+	/**
+	 * Check if this activity requires notification permission to continue.
+	 *
+	 * @return true if notification permission is required.
+	 */
+	protected boolean isNotificationPermissionRequiredForActivity() {
+		return false;
+	}
+
+	/**
+	 * Check if startup may request notification permission opportunistically.
+	 *
+	 * @return true if startup may request notification permission.
+	 */
+	protected boolean shouldRequestNotificationPermissionOnStartup() {
+		return true;
+	}
+
+	/**
+	 * Check if image access permissions are missing.
+	 *
+	 * @return true if an image access permission is missing.
+	 */
+	private boolean isImagePermissionMissing() {
+		int readPermission = ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE);
+		int writePermission = ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+		int locationPermission = PackageManager.PERMISSION_GRANTED;
+		int mediaPermission = PackageManager.PERMISSION_GRANTED;
+		if (Build.VERSION.SDK_INT >= VERSION_CODES.R) {
+			locationPermission = ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_MEDIA_LOCATION);
+		}
+		if (Build.VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+			mediaPermission = ContextCompat.checkSelfPermission(this, permission.READ_MEDIA_IMAGES);
+		}
+
+		return (!SystemUtil.isAtLeastVersion(VERSION_CODES.TIRAMISU) && readPermission != PackageManager.PERMISSION_GRANTED) // BOOLEAN_EXPRESSION_COMPLEXITY
+				|| (!SystemUtil.isAtLeastVersion(VERSION_CODES.Q) && writePermission != PackageManager.PERMISSION_GRANTED)
+				|| (SystemUtil.isAtLeastVersion(VERSION_CODES.R) && locationPermission != PackageManager.PERMISSION_GRANTED)
+				|| (SystemUtil.isAtLeastVersion(VERSION_CODES.TIRAMISU) && mediaPermission != PackageManager.PERMISSION_GRANTED);
+	}
+
+	/**
+	 * Create the list of permissions to request.
+	 *
+	 * @param requireNotificationPermission true if notification permission is required for continuing.
+	 * @return The permissions to request.
+	 */
+	private String[] createPermissionRequest(final boolean requireNotificationPermission) {
+		List<String> permissions = new ArrayList<>();
+		if (Build.VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+			permissions.add(permission.ACCESS_MEDIA_LOCATION);
+			permissions.add(permission.READ_MEDIA_IMAGES);
+			if (requireNotificationPermission
+					|| (shouldRequestNotificationPermissionOnStartup() && NotificationPermissionUtil.shouldRequestStartupNotificationPermission(this))) {
+				permissions.add(permission.POST_NOTIFICATIONS);
+				NotificationPermissionUtil.markNotificationPermissionRequested();
+			}
+		}
+		else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+			permissions.add(permission.READ_EXTERNAL_STORAGE);
+			permissions.add(permission.WRITE_EXTERNAL_STORAGE);
+			permissions.add(permission.ACCESS_MEDIA_LOCATION);
+		}
+		else {
+			permissions.add(permission.READ_EXTERNAL_STORAGE);
+			permissions.add(permission.WRITE_EXTERNAL_STORAGE);
+		}
+		return permissions.toArray(new String[0]);
 	}
 
 	// OVERRIDABLE
 	@Override
 	public void onRequestPermissionsResult(final int requestCode, @NonNull final String[] permissions, @NonNull final int[] grantResults) {
 		if (requestCode == REQUEST_CODE_PERMISSION) {
-			// If request is cancelled, the result arrays are empty.
-			if (grantResults.length == 0 || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
+			if (!areRequiredPermissionsGranted()) {
 				finish();
+				return;
 			}
 			ImageUtil.init();
 			DialogUtil.displaySearchForImageFoldersIfRequired(this, false);
@@ -89,6 +151,16 @@ public abstract class StartActivity extends BaseActivity {
 				startActivity(intent);
 			}
 		}
+	}
+
+	/**
+	 * Check whether all permissions required to continue are granted.
+	 *
+	 * @return true if all required permissions are granted.
+	 */
+	private boolean areRequiredPermissionsGranted() {
+		return !isImagePermissionMissing()
+				&& (!isNotificationPermissionRequiredForActivity() || NotificationPermissionUtil.hasNotificationPermission(this));
 	}
 
 	/**

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationActivity.java
@@ -1,11 +1,15 @@
 package de.jeisfeld.randomimage.notifications;
 
+import android.app.DialogFragment;
 import android.content.Intent;
 import android.os.Bundle;
 import android.preference.PreferenceFragment;
 
 import de.jeisfeld.randomimage.StartActivity;
+import de.jeisfeld.randomimage.util.DialogUtil;
+import de.jeisfeld.randomimage.util.DialogUtil.ConfirmDialogFragment.ConfirmDialogListener;
 import de.jeisfeld.randomimage.util.NotificationPermissionUtil;
+import de.jeisfeld.randomimagelib.R;
 
 /**
  * Activity for the configuration of a notification.
@@ -35,7 +39,7 @@ public class NotificationConfigurationActivity extends StartActivity {
 	protected final void onCreate(final Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		if (!NotificationPermissionUtil.hasNotificationPermission(this)) {
-			NotificationPermissionUtil.requestNotificationPermission(this, REQUEST_CODE_NOTIFICATION_PERMISSION);
+			requestNotificationPermission();
 			return;
 		}
 		getWindow().getDecorView().setFitsSystemWindows(true);
@@ -70,6 +74,23 @@ public class NotificationConfigurationActivity extends StartActivity {
 		}
 	}
 
+	/**
+	 * Request the notification permission after explaining why it is required.
+	 */
+	private void requestNotificationPermission() {
+		DialogUtil.displayConfirmationMessage(this, new ConfirmDialogListener() {
+			@Override
+			public void onDialogPositiveClick(final DialogFragment dialog) {
+				NotificationPermissionUtil.requestNotificationPermission(NotificationConfigurationActivity.this, REQUEST_CODE_NOTIFICATION_PERMISSION);
+			}
+
+			@Override
+			public void onDialogNegativeClick(final DialogFragment dialog) {
+				finish();
+			}
+		}, R.string.title_dialog_request_permission, R.string.button_continue, R.string.dialog_confirmation_need_notification_permission);
+	}
+
 	@Override
 	public final void onRequestPermissionsResult(final int requestCode, final String[] permissions, final int[] grantResults) {
 		if (requestCode == REQUEST_CODE_NOTIFICATION_PERMISSION) {
@@ -77,7 +98,7 @@ public class NotificationConfigurationActivity extends StartActivity {
 				recreate();
 			}
 			else {
-				finish();
+				DialogUtil.displayInfo(this, () -> finish(), 0, R.string.dialog_confirmation_need_notification_permission);
 			}
 		}
 		else {

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.preference.PreferenceFragment;
 
 import de.jeisfeld.randomimage.StartActivity;
+import de.jeisfeld.randomimage.util.NotificationPermissionUtil;
 
 /**
  * Activity for the configuration of a notification.
@@ -16,13 +17,27 @@ public class NotificationConfigurationActivity extends StartActivity {
 	private static final String FRAGMENT_TAG = "FRAGMENT_TAG";
 
 	/**
+	 * The request code used to query for notification permission.
+	 */
+	private static final int REQUEST_CODE_NOTIFICATION_PERMISSION = 4;
+
+	/**
 	 * The Intent used as result.
 	 */
 	private Intent mResultValue;
 
 	@Override
+	protected final boolean shouldRequestNotificationPermissionOnStartup() {
+		return false;
+	}
+
+	@Override
 	protected final void onCreate(final Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		if (!NotificationPermissionUtil.hasNotificationPermission(this)) {
+			NotificationPermissionUtil.requestNotificationPermission(this, REQUEST_CODE_NOTIFICATION_PERMISSION);
+			return;
+		}
 		getWindow().getDecorView().setFitsSystemWindows(true);
 
 		setResult(RESULT_CANCELED);
@@ -52,6 +67,21 @@ public class NotificationConfigurationActivity extends StartActivity {
 
 			getFragmentManager().beginTransaction().replace(android.R.id.content, fragment, FRAGMENT_TAG).commit();
 			getFragmentManager().executePendingTransactions();
+		}
+	}
+
+	@Override
+	public final void onRequestPermissionsResult(final int requestCode, final String[] permissions, final int[] grantResults) {
+		if (requestCode == REQUEST_CODE_NOTIFICATION_PERMISSION) {
+			if (NotificationPermissionUtil.hasNotificationPermission(this)) {
+				recreate();
+			}
+			else {
+				finish();
+			}
+		}
+		else {
+			super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 		}
 	}
 

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationConfigurationActivity.java
@@ -98,7 +98,7 @@ public class NotificationConfigurationActivity extends StartActivity {
 				recreate();
 			}
 			else {
-				DialogUtil.displayInfo(this, () -> finish(), 0, R.string.dialog_confirmation_need_notification_permission);
+				finish();
 			}
 		}
 		else {

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationSettingsActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationSettingsActivity.java
@@ -17,6 +17,7 @@ import de.jeisfeld.randomimage.Application;
 import de.jeisfeld.randomimage.BasePreferenceActivity;
 import de.jeisfeld.randomimage.util.DialogUtil;
 import de.jeisfeld.randomimage.util.DialogUtil.ConfirmDialogFragment.ConfirmDialogListener;
+import de.jeisfeld.randomimage.util.NotificationPermissionUtil;
 import de.jeisfeld.randomimage.util.PreferenceUtil;
 import de.jeisfeld.randomimage.util.SystemUtil;
 import de.jeisfeld.randomimagelib.R;
@@ -29,6 +30,11 @@ public class NotificationSettingsActivity extends BasePreferenceActivity {
 	 * Resource String for the hash code parameter used to identify the instance of the activity.
 	 */
 	public static final String STRING_HASH_CODE = "de.jeisfeld.randomimage.HASH_CODE";
+
+	/**
+	 * The request code used to query for notification permission.
+	 */
+	private static final int REQUEST_CODE_NOTIFICATION_PERMISSION = 4;
 
 	/**
 	 * The headers that are displayed.
@@ -61,6 +67,18 @@ public class NotificationSettingsActivity extends BasePreferenceActivity {
 
 		mActivityMap.put(hashCode(), this);
 
+		if (!NotificationPermissionUtil.hasNotificationPermission(this)) {
+			NotificationPermissionUtil.requestNotificationPermission(this, REQUEST_CODE_NOTIFICATION_PERMISSION);
+			return;
+		}
+
+		requestAlarmPermissionIfRequired();
+	}
+
+	/**
+	 * Request exact alarm permission, if required.
+	 */
+	private void requestAlarmPermissionIfRequired() {
 		AlarmManager alarmMgr = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
 		if (SystemUtil.isAtLeastVersion(VERSION_CODES.UPSIDE_DOWN_CAKE) && alarmMgr != null && !alarmMgr.canScheduleExactAlarms()) {
 			DialogUtil.displayConfirmationMessage(this, new ConfirmDialogListener() {
@@ -75,6 +93,18 @@ public class NotificationSettingsActivity extends BasePreferenceActivity {
 					finish();
 				}
 			}, R.string.title_dialog_request_permission, R.string.button_continue, R.string.dialog_confirmation_need_alarm_permission);
+		}
+	}
+
+	@Override
+	public final void onRequestPermissionsResult(final int requestCode, final String[] permissions, final int[] grantResults) {
+		if (requestCode == REQUEST_CODE_NOTIFICATION_PERMISSION) {
+			if (NotificationPermissionUtil.hasNotificationPermission(this)) {
+				requestAlarmPermissionIfRequired();
+			}
+			else {
+				finish();
+			}
 		}
 	}
 

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationSettingsActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationSettingsActivity.java
@@ -68,11 +68,28 @@ public class NotificationSettingsActivity extends BasePreferenceActivity {
 		mActivityMap.put(hashCode(), this);
 
 		if (!NotificationPermissionUtil.hasNotificationPermission(this)) {
-			NotificationPermissionUtil.requestNotificationPermission(this, REQUEST_CODE_NOTIFICATION_PERMISSION);
+			requestNotificationPermission();
 			return;
 		}
 
 		requestAlarmPermissionIfRequired();
+	}
+
+	/**
+	 * Request the notification permission after explaining why it is required.
+	 */
+	private void requestNotificationPermission() {
+		DialogUtil.displayConfirmationMessage(this, new ConfirmDialogListener() {
+			@Override
+			public void onDialogPositiveClick(final DialogFragment dialog) {
+				NotificationPermissionUtil.requestNotificationPermission(NotificationSettingsActivity.this, REQUEST_CODE_NOTIFICATION_PERMISSION);
+			}
+
+			@Override
+			public void onDialogNegativeClick(final DialogFragment dialog) {
+				finish();
+			}
+		}, R.string.title_dialog_request_permission, R.string.button_continue, R.string.dialog_confirmation_need_notification_permission);
 	}
 
 	/**
@@ -103,7 +120,7 @@ public class NotificationSettingsActivity extends BasePreferenceActivity {
 				requestAlarmPermissionIfRequired();
 			}
 			else {
-				finish();
+				DialogUtil.displayInfo(this, () -> finish(), 0, R.string.dialog_confirmation_need_notification_permission);
 			}
 		}
 	}

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationSettingsActivity.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationSettingsActivity.java
@@ -120,7 +120,7 @@ public class NotificationSettingsActivity extends BasePreferenceActivity {
 				requestAlarmPermissionIfRequired();
 			}
 			else {
-				DialogUtil.displayInfo(this, () -> finish(), 0, R.string.dialog_confirmation_need_notification_permission);
+				finish();
 			}
 		}
 	}

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationUtil.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationUtil.java
@@ -42,6 +42,7 @@ import de.jeisfeld.randomimage.util.ImageRegistry;
 import de.jeisfeld.randomimage.util.ImageRegistry.ListFiltering;
 import de.jeisfeld.randomimage.util.ImageUtil;
 import de.jeisfeld.randomimage.util.MediaStoreUtil;
+import de.jeisfeld.randomimage.util.NotificationPermissionUtil;
 import de.jeisfeld.randomimage.util.PreferenceUtil;
 import de.jeisfeld.randomimage.util.SystemUtil;
 import de.jeisfeld.randomimagelib.R;
@@ -167,6 +168,9 @@ public final class NotificationUtil {
 	 */
 	public static void displayNotification(final Context context, final String notificationTag, final NotificationType notificationType,
 										   final int titleResource, final int messageResource, final Object... args) {
+		if (!NotificationPermissionUtil.hasNotificationPermission(context)) {
+			return;
+		}
 		String message = DialogUtil.capitalizeFirst(context.getString(messageResource, args));
 		String title = context.getString(titleResource, notificationTag);
 
@@ -414,6 +418,10 @@ public final class NotificationUtil {
 			notificationBuilder.setVibrate(VIBRATION_PATTERN);
 		}
 
+		if (!NotificationPermissionUtil.hasNotificationPermission(context)) {
+			return;
+		}
+
 		NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 		notificationManager.notify(notificationTag, notificationType.intValue(), notificationBuilder.build());
 
@@ -538,7 +546,7 @@ public final class NotificationUtil {
 										 final List<String> nestedLists, final List<String> folders, final List<String> files) {
 		// Do not show notification if globally disabled.
 		boolean showNotification = PreferenceUtil.getSharedPreferenceBoolean(R.string.key_pref_show_list_notification);
-		if (!showNotification) {
+		if (!showNotification || !NotificationPermissionUtil.hasNotificationPermission(context)) {
 			return;
 		}
 

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/util/NotificationPermissionUtil.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/util/NotificationPermissionUtil.java
@@ -1,0 +1,85 @@
+package de.jeisfeld.randomimage.util;
+
+import android.Manifest.permission;
+import android.app.Activity;
+import android.app.Fragment;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build.VERSION_CODES;
+
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+import de.jeisfeld.randomimagelib.R;
+
+/**
+ * Utility class for handling the notification runtime permission.
+ */
+public final class NotificationPermissionUtil {
+	/**
+	 * Hide default constructor.
+	 */
+	private NotificationPermissionUtil() {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Check if the notification runtime permission applies on this device.
+	 *
+	 * @return true if notification permission must be checked/requested.
+	 */
+	public static boolean isNotificationPermissionRequired() {
+		return SystemUtil.isAtLeastVersion(VERSION_CODES.TIRAMISU);
+	}
+
+	/**
+	 * Check if the app may post notifications.
+	 *
+	 * @param context The context.
+	 * @return true if notification permission is granted or not required on this device.
+	 */
+	public static boolean hasNotificationPermission(final Context context) {
+		return !isNotificationPermissionRequired()
+				|| ContextCompat.checkSelfPermission(context, permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED;
+	}
+
+	/**
+	 * Check if startup should ask for the notification permission.
+	 *
+	 * @param context The context.
+	 * @return true if startup should ask for notification permission.
+	 */
+	public static boolean shouldRequestStartupNotificationPermission(final Context context) {
+		return isNotificationPermissionRequired()
+				&& !hasNotificationPermission(context)
+				&& !PreferenceUtil.getSharedPreferenceBoolean(R.string.key_pref_notification_permission_requested);
+	}
+
+	/**
+	 * Request notification permission from an activity.
+	 *
+	 * @param activity    The activity.
+	 * @param requestCode The request code.
+	 */
+	public static void requestNotificationPermission(final Activity activity, final int requestCode) {
+		markNotificationPermissionRequested();
+		ActivityCompat.requestPermissions(activity, new String[]{permission.POST_NOTIFICATIONS}, requestCode);
+	}
+
+	/**
+	 * Request notification permission from a fragment.
+	 *
+	 * @param fragment    The fragment.
+	 * @param requestCode The request code.
+	 */
+	public static void requestNotificationPermission(final Fragment fragment, final int requestCode) {
+		markNotificationPermissionRequested();
+		fragment.requestPermissions(new String[]{permission.POST_NOTIFICATIONS}, requestCode);
+	}
+
+	/**
+	 * Mark that notification permission has been requested.
+	 */
+	public static void markNotificationPermissionRequested() {
+		PreferenceUtil.setSharedPreferenceBoolean(R.string.key_pref_notification_permission_requested, true);
+	}
+}

--- a/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/util/NotificationPermissionUtil.java
+++ b/RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/util/NotificationPermissionUtil.java
@@ -55,13 +55,24 @@ public final class NotificationPermissionUtil {
 	}
 
 	/**
+	 * Request notification permission from an activity during app startup.
+	 * This method records that the startup-only request has already happened, so startup does not nag again.
+	 *
+	 * @param activity    The activity.
+	 * @param requestCode The request code.
+	 */
+	public static void requestStartupNotificationPermission(final Activity activity, final int requestCode) {
+		markNotificationPermissionRequested();
+		requestNotificationPermission(activity, requestCode);
+	}
+
+	/**
 	 * Request notification permission from an activity.
 	 *
 	 * @param activity    The activity.
 	 * @param requestCode The request code.
 	 */
 	public static void requestNotificationPermission(final Activity activity, final int requestCode) {
-		markNotificationPermissionRequested();
 		ActivityCompat.requestPermissions(activity, new String[]{permission.POST_NOTIFICATIONS}, requestCode);
 	}
 
@@ -72,7 +83,6 @@ public final class NotificationPermissionUtil {
 	 * @param requestCode The request code.
 	 */
 	public static void requestNotificationPermission(final Fragment fragment, final int requestCode) {
-		markNotificationPermissionRequested();
 		fragment.requestPermissions(new String[]{permission.POST_NOTIFICATIONS}, requestCode);
 	}
 

--- a/RandomImageIdea/randomImageLib/src/main/res/values-de/strings_dialogs.xml
+++ b/RandomImageIdea/randomImageLib/src/main/res/values-de/strings_dialogs.xml
@@ -114,6 +114,7 @@
     <string name="dialog_confirmation_need_read_permission">Die App benötigt Zugriff auf den Speicher, um auf Ihre Bilder zugreifen zu können. Bitte erlauben Sie diesen Zugriff - andernfalls wird die App nicht funktionieren.</string>
     <string name="dialog_confirmation_need_image_permission">Diese App muss die Berechtigung für Bilder und Benachrichtigungen haben. Bitte geben Sie diese - sonst funktioniert die App nicht richtig.</string>
     <string name="dialog_confirmation_need_alarm_permission">Zur Konfiguration von Benachrichtigungen benötigt die App die Berechtigung zum Einstellen von Alarmen.</string>
+    <string name="dialog_confirmation_need_notification_permission">Diese Funktion benötigt die Berechtigung für Benachrichtigungen. Bitte erlauben Sie Benachrichtigungen, um fortzufahren.</string>
     <string name="dialog_confirmation_need_usage_access">Um Popup-Benachrichtigungen für bestimmte Apps zu unterdrücken, benötigt Zufallsbild Zugriffs auf Nutzungsdaten. Bitte gewähren Sie diese im folgenden Einstellungsdialog.</string>
 
     <!-- Partial strings used to construct other strings -->

--- a/RandomImageIdea/randomImageLib/src/main/res/values-es/strings_dialogs.xml
+++ b/RandomImageIdea/randomImageLib/src/main/res/values-es/strings_dialogs.xml
@@ -113,6 +113,7 @@
     <string name="dialog_confirmation_need_read_permission">La aplicación necesita acceso almacenamiento externo para acceder a sus imágenes. Permita este acceso; de lo contrario, la aplicación no funcionará.</string>
     <string name="dialog_confirmation_need_image_permission">Esta aplicación necesita tener permiso en imágenes y notificaciones. Por favor, entréguelos; de lo contrario, la aplicación no funcionará correctamente.</string>
     <string name="dialog_confirmation_need_alarm_permission">Para la configuración de notificaciones, la aplicación necesita permiso para configurar alarmas.</string>
+    <string name="dialog_confirmation_need_notification_permission">Esta función necesita permiso de notificaciones. Permita las notificaciones para continuar.</string>
     <string name="dialog_confirmation_need_usage_access">Para evitar notificaciones emergentes para ciertas aplicaciones, la aplicación necesita acceso a los datos de acceso de uso. Por favor conceda este acceso en la siguiente página</string>
 
     <!-- Partial strings used to construct other strings -->

--- a/RandomImageIdea/randomImageLib/src/main/res/values/strings_dialogs.xml
+++ b/RandomImageIdea/randomImageLib/src/main/res/values/strings_dialogs.xml
@@ -115,6 +115,7 @@
     <string name="dialog_confirmation_need_read_permission">This app needs to have permission on your external storage in order to access the images. Please provide this access - otherwise the app will not work.</string>
     <string name="dialog_confirmation_need_image_permission">This app needs to have permission on images and notifications. Please give these - otherwise the app will not work properly.</string>
     <string name="dialog_confirmation_need_alarm_permission">For configuration of notifications the app needs permission to set alarms.</string>
+    <string name="dialog_confirmation_need_notification_permission">This feature needs notification permission. Please allow notifications to continue.</string>
     <string name="dialog_confirmation_need_usage_access">In order to prevent popup notifications for certain apps, RandomImage needs access to Usage Access data. Please grant this access on the following page.</string>
 
     <!-- Partial strings used to construct other strings -->

--- a/RandomImageIdea/randomImageLib/src/main/res/values/strings_preferences.xml
+++ b/RandomImageIdea/randomImageLib/src/main/res/values/strings_preferences.xml
@@ -7,6 +7,7 @@
     <string name="key_pref_folder_selection_mechanism" translatable="false">pref_folder_selection_mechanism</string>
     <string name="key_pref_show_hidden_folders" translatable="false">pref_show_hidden_folders</string>
     <string name="key_pref_show_list_notification" translatable="false">pref_show_list_notification</string>
+    <string name="key_pref_notification_permission_requested" translatable="false">pref_notification_permission_requested</string>
     <string name="key_pref_use_regex_filter" translatable="false">pref_use_regex_filter</string>
     <string name="key_pref_hidden_lists_pattern" translatable="false">pref_hidden_lists_pattern</string>
     <string name="key_pref_hidden_folders_pattern" translatable="false">pref_hidden_folders_pattern</string>


### PR DESCRIPTION
### Motivation

- The app currently blocks startup if notification permission is denied, but most features do not require it; startup should proceed without notifications while still requesting the permission once initially.
- Certain flows (configuring a random image notification or enabling “notify on list change”) must still enforce notification permission to prevent misconfigured settings.

### Description

- Added a new utility `NotificationPermissionUtil` to centralize notification-permission checks, one-time startup-request tracking, and request helpers for activities and fragments (`RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/util/NotificationPermissionUtil.java`).
- Changed startup logic in `StartActivity` to require image/media permissions as before but to request notification permission opportunistically only once (and not block startup if denied), with overrides to require notification permission for specific activities (`RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/StartActivity.java`).
- Enforced notification permission before entering notification settings/configuration by requesting it and returning early if not granted in `NotificationSettingsActivity` and `NotificationConfigurationActivity` (`.../notifications/NotificationSettingsActivity.java`, `.../notifications/NotificationConfigurationActivity.java`).
- Enforced notification permission when the user enables the “Notify on list change” checkbox in settings and automatically checks the preference when the permission is granted (`RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/SettingsFragment.java`).
- Guarded all notification posting paths so notifications are skipped when the runtime permission is not available (`RandomImageIdea/randomImageLib/src/main/java/de/jeisfeld/randomimage/notifications/NotificationUtil.java`).
- Added a preference key to track that the startup notification request already happened (`RandomImageIdea/randomImageLib/src/main/res/values/strings_preferences.xml`).

### Testing

- Ran `git diff --check` which produced no check failures for the working changes.
- Attempted to build with `bash ./gradlew assembleDebug` but it failed due to missing Gradle wrapper files (`org.gradle.wrapper.GradleWrapperMain`), so the wrapper build could not be executed in this environment.
- Attempted to build with the system `gradle assembleDebug`, which failed because the installed Gradle (8.14.4) is older than the required Gradle version (9.3.1) for the Android Gradle plugin used by the project, so a full automated build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b8f9b088c832290acdb467dad92c7)